### PR TITLE
Minor User Guide formatting fixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -269,6 +269,7 @@ Deletes an existing group and removes all group assignments from associated cont
 Format:
 
 `group/delete g/GROUP_NAME`
+
 --------------------------------------------------------------------------------------------------------------------
 ### List Groups: `group/list`
 
@@ -277,6 +278,7 @@ Displays all existing groups.
 Format:
 
 `group/list`
+
 --------------------------------------------------------------------------------------------------------------------
 ### Assign Group: `group/assign`
 
@@ -287,6 +289,7 @@ If the specified group does not exist, EduTrack will prompt you to create it fir
 Format:
 
 `group/assign g/GROUP_NAME INDEX [MORE_INDEXES...]`
+
 --------------------------------------------------------------------------------------------------------------------
 ### Unassign Group: `group/unassign`
 


### PR DESCRIPTION
Noticed that code blocks for group commands in UG were of inconsistent size with the rest of the UG. Fixed by adding a line break. 