### PR TITLE
Fix exit handler in MainWindow

### DIFF
--- a/src/main/java/edutrack/ui/MainWindow.java
+++ b/src/main/java/edutrack/ui/MainWindow.java
@@ -170,6 +170,7 @@ public class MainWindow extends UiPart<Stage> {
                 (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
+        statsWindow.hide();
         primaryStage.hide();
     }
 


### PR DESCRIPTION
Fixes #143 

Added a line that hides the StatsWindow in the exit handler of MainWindow.