### PR TITLE
Add line in UG clarifying tag and group creation limitations

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -250,9 +250,7 @@ Exits the program.
 Format: `exit`
 
 
-
 --------------------------------------------------------------------------------------------------------------------
-
 
 ### Create Group: `group/create`
 
@@ -264,6 +262,8 @@ Format:
 
 * `GROUP_NAME` refers to the name you wish to assign to the group.
 * `GROUP_NAME` is case-insensitive and acceptable characters are alpha-numeric.​
+* Spaces are not allowed.
+
 --------------------------------------------------------------------------------------------------------------------
 ### Delete Group: `group/delete`
 


### PR DESCRIPTION
Tags and groups are not allowed to have spaces. Though implied by the current limitations mentioned, it might not be very clear and could use an explicit line to bring attention to this. 