### PR TITLE
Change add command details to be less vague

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -443,11 +443,10 @@ EduTrack data are saved automatically as a JSON file at this file location:
 Advanced users are welcome to update data directly by editing that data file.
 
 
-
-> [!CAUTION]
-> If your changes to the data file makes its format invalid, Edutrack will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
-> Furthermore, certain edits can cause the EduTrack to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
-
+<div markdown="span" class="alert alert-warning"> :exclamation:  **Caution**  For ADVANCED users:
+If your changes to the data file makes its format invalid, Edutrack will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
+Furthermore, certain edits can cause the EduTrack to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+</div>
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #138. 

Changes:
- added hyperlinks to respective create commands for users to access naming restrictions for groups and tags
- added note to specify that duplicate persons are not allowed to be created