### PR TITLE
Update delete error message

### DIFF
--- a/src/main/java/edutrack/logic/commands/DeleteCommand.java
+++ b/src/main/java/edutrack/logic/commands/DeleteCommand.java
@@ -20,7 +20,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer within the range of the displayed list)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";


### PR DESCRIPTION
fixes #239 

New Error Message for delete that states index must be within range of displayed list

Invalid command format! 
delete: Deletes the person identified by the index number used in the displayed person list.
Parameters: INDEX (must be a positive integer within the range of the displayed list)
Example: delete 1

